### PR TITLE
Hide application in dock

### DIFF
--- a/Cooldown.xcodeproj/project.pbxproj
+++ b/Cooldown.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1F70779527667D0800E69FC3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		C2104CF5273593CA0083B0AF /* MapKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MapKit.framework; path = System/Library/Frameworks/MapKit.framework; sourceTree = SDKROOT; };
 		C2104CFB273596020083B0AF /* CooldownRelease.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = CooldownRelease.entitlements; sourceTree = "<group>"; };
 		C21D060927353F8A006548E2 /* Cooldown.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Cooldown.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -104,6 +105,7 @@
 		C21D060B27353F8A006548E2 /* Cooldown */ = {
 			isa = PBXGroup;
 			children = (
+				1F70779527667D0800E69FC3 /* Info.plist */,
 				C2104CFB273596020083B0AF /* CooldownRelease.entitlements */,
 				C21D060C27353F8A006548E2 /* CooldownApp.swift */,
 				C21D063B27355C7E006548E2 /* StatusBar.swift */,
@@ -451,6 +453,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Cooldown/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -482,6 +485,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = Cooldown/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/Cooldown/Info.plist
+++ b/Cooldown/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>LSUIElement</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
I added `Application is agent (UIElement)` in the Info.plist, so the icon does not show in the dock. 
I'm not sure if this is a feature you want, but it's something I like. You can take it or leave it.